### PR TITLE
🔧 Add heart-centered-ai.mdc sync step to generate-detail-levels command

### DIFF
--- a/.claude/commands/generate-detail-levels.md
+++ b/.claude/commands/generate-detail-levels.md
@@ -16,11 +16,11 @@ independent documents. Run this whenever comprehensive.txt changes.
 <size-targets>
 Character counts (verify with `wc -c prompts/align_to_love/*.txt`):
 
-| Tier | Target | Hard bounds |
-|------|--------|-------------|
+| Tier     | Target                | Hard bounds     |
+| -------- | --------------------- | --------------- |
 | standard | ~45% of comprehensive | 2500-4500 chars |
-| concise | ~20% of comprehensive | 1100-1900 chars |
-| terse | single paragraph | 550-1000 chars |
+| concise  | ~20% of comprehensive | 1100-1900 chars |
+| terse    | single paragraph      | 550-1000 chars  |
 
 Tests in both packages assert strict ordering (terse < concise < standard <
 comprehensive) plus absolute length bounds. Read the current assertions in
@@ -75,7 +75,15 @@ into flowing prose.
      `uv.lock` it creates)
    - `cd typescript && pnpm generate && pnpm test` (run `pnpm install` first
      only if `node_modules/` is missing)
-5. Refresh approximate token counts wherever docs state them (chars / 4 is a
+5. Sync `.cursor/rules/heart-centered-ai.mdc`: the body of that file mirrors
+   `comprehensive.txt` exactly (the first five lines are YAML frontmatter;
+   everything after is the prompt). Replace lines 6 onward with the new
+   comprehensive content so the always-on IDE rule stays in sync:
+   ```
+   head -5 .cursor/rules/heart-centered-ai.mdc > /tmp/mdc_header
+   cat /tmp/mdc_header prompts/align_to_love/comprehensive.txt > .cursor/rules/heart-centered-ai.mdc
+   ```
+6. Refresh approximate token counts wherever docs state them (chars / 4 is a
    fine estimate). Find every location with `git grep -n '~[0-9]* tokens'`.
-6. Report the new character counts and what was cut from each tier.
+7. Report the new character counts and what was cut from each tier.
 </process>

--- a/.claude/commands/generate-detail-levels.md
+++ b/.claude/commands/generate-detail-levels.md
@@ -67,15 +67,7 @@ into flowing prose.
 1. Read `prompts/align_to_love/comprehensive.txt` in full. List its themes in order.
 2. Write standard.txt, then concise.txt, then terse.txt, each derived from
    comprehensive (not from each other, and not from the previous versions).
-3. Verify: `pre-commit run forbid-em-dashes --all-files` must pass; `wc -c`
-   must satisfy the bounds above.
-4. Sync and test, both packages must pass:
-   - `cd python && python3 copy_prompts.py && pytest -q` (use
-     `uv run --with pytest pytest -q` if pytest is missing; delete any
-     `uv.lock` it creates)
-   - `cd typescript && pnpm generate && pnpm test` (run `pnpm install` first
-     only if `node_modules/` is missing)
-5. Sync `.cursor/rules/heart-centered-ai.mdc`: the body of that file mirrors
+3. Sync `.cursor/rules/heart-centered-ai.mdc`: the body of that file mirrors
    `comprehensive.txt` exactly (the first five lines are YAML frontmatter;
    everything after is the prompt). Replace lines 6 onward with the new
    comprehensive content so the always-on IDE rule stays in sync:
@@ -83,6 +75,14 @@ into flowing prose.
    head -5 .cursor/rules/heart-centered-ai.mdc > /tmp/mdc_header
    cat /tmp/mdc_header prompts/align_to_love/comprehensive.txt > .cursor/rules/heart-centered-ai.mdc
    ```
+4. Verify: `pre-commit run forbid-em-dashes --all-files` must pass; `wc -c`
+   must satisfy the bounds above.
+5. Sync and test, both packages must pass:
+   - `cd python && python3 copy_prompts.py && pytest -q` (use
+     `uv run --with pytest pytest -q` if pytest is missing; delete any
+     `uv.lock` it creates)
+   - `cd typescript && pnpm generate && pnpm test` (run `pnpm install` first
+     only if `node_modules/` is missing)
 6. Refresh approximate token counts wherever docs state them (chars / 4 is a
    fine estimate). Find every location with `git grep -n '~[0-9]* tokens'`.
 7. Report the new character counts and what was cut from each tier.


### PR DESCRIPTION
## Summary

- Adds step 5 to the `generate-detail-levels` process: after regenerating the shorter tiers, sync `.cursor/rules/heart-centered-ai.mdc` so the always-on IDE rule stays in lockstep with `comprehensive.txt`

## Context

`.cursor/rules/heart-centered-ai.mdc` (body after frontmatter) is identical to `comprehensive.txt` and is `alwaysApply: true` in the IDE. Without an explicit sync step it silently drifts on the next comprehensive edit. `AGENTS.md` references this file, so drift means the AI context the IDE loads becomes stale.

The fix adds a clear one-liner to re-stamp the file while preserving the 5-line YAML frontmatter.

Addresses cursor[bot] comment on merged PR #8 (`5858ae0e-1d12-4075-97c0-38211f10a364`).

## Test plan

- [x] `diff <(sed '1,5d' .cursor/rules/heart-centered-ai.mdc) prompts/align_to_love/comprehensive.txt` returns nothing (currently identical, sync step keeps it that way)
- [x] Command reads correctly end-to-end; step numbering is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)